### PR TITLE
fix: correctly infer the type of the function passed to derived

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -971,6 +971,26 @@ describe('stores', () => {
       });
     });
 
+    it('should infer types automatically in the async case', () => {
+      const a = writable(1);
+      const b = writable(2);
+      const sum = derived(
+        [a, b],
+        ([a, b], set) => {
+          set(a + b);
+        },
+        0
+      );
+      expect(get(sum)).toBe(3);
+    });
+
+    it('should infer types automatically in the sync case', () => {
+      const a = writable(1);
+      const b = writable(2);
+      const sum = derived([a, b], ([a, b]) => a + b);
+      expect(get(sum)).toBe(3);
+    });
+
     it('should call clean-up function returned in deriveFn with derived', () => {
       const a = writable(1);
       const cleanUpFn = jasmine.createSpy('cleanupFn').and.callThrough();

--- a/src/index.ts
+++ b/src/index.ts
@@ -752,13 +752,13 @@ export abstract class DerivedStore<
  */
 export function derived<T, S extends SubscribableStores>(
   stores: S,
-  options: SyncDeriveFn<T, S> | SyncDeriveOptions<T, S>,
-  initialValue?: T
+  options: AsyncDeriveFn<T, S> | AsyncDeriveOptions<T, S>,
+  initialValue: T
 ): Readable<T>;
 export function derived<T, S extends SubscribableStores>(
   stores: S,
-  options: AsyncDeriveFn<T, S> | AsyncDeriveOptions<T, S>,
-  initialValue: T
+  options: SyncDeriveFn<T, S> | SyncDeriveOptions<T, S>,
+  initialValue?: T
 ): Readable<T>;
 export function derived<T, S extends SubscribableStores>(
   stores: S,


### PR DESCRIPTION
Before this PR, the type of the function passed to derived was not correctly inferred by typescript in the async case. By putting the async case first in the list of overloads of the derived function, it looks like it fixes the issue, and the type is still correctly inferred in the sync case too.