### PR TITLE
fix: not re-emit with the `null` value

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -633,18 +633,33 @@ describe('stores', () => {
       const strStore = writable('foo');
       const boolStore = writable(true);
       const undefinedStore = writable(undefined);
+      const nullStore = writable(null);
 
       numStore.subscribe((v) => values.push(v));
       strStore.subscribe((v) => values.push(v));
       boolStore.subscribe((v) => values.push(v));
       undefinedStore.subscribe((v) => values.push(v));
-      expect(values).toEqual([5, 'foo', true, undefined]);
+      nullStore.subscribe((v) => values.push(v));
+      expect(values).toEqual([5, 'foo', true, undefined, null]);
 
       numStore.set(5);
       strStore.set('foo');
       boolStore.set(true);
       undefinedStore.set(undefined);
-      expect(values).toEqual([5, 'foo', true, undefined]);
+      nullStore.set(null);
+      expect(values).toEqual([5, 'foo', true, undefined, null]);
+    });
+
+    it('should re-emit for an object even if it does not change', () => {
+      const values: any[] = [];
+      const ref = {};
+      const objectStore = writable(ref);
+
+      objectStore.subscribe((v) => values.push(v));
+      expect(values).toEqual([ref]);
+
+      objectStore.set(ref);
+      expect(values).toEqual([ref, ref]);
     });
 
     it('should not emit when setting NaN', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,11 +341,7 @@ export abstract class Store<T> implements Readable<T> {
    * @returns true if a and b are considered different.
    */
   protected notEqual(a: T, b: T): boolean {
-    const tOfA = typeof a;
-    if (tOfA !== 'function' && tOfA !== 'object') {
-      return !Object.is(a, b);
-    }
-    return true;
+    return !Object.is(a, b) || (a && typeof a === 'object') || typeof a === 'function';
   }
 
   /**


### PR DESCRIPTION
Fix #54 