### PR TITLE
chore: directly use the index.d.ts file generated by tsc

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "dist/dts/index.d.ts",
+  "mainEntryPointFilePath": "dist/package/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.
@@ -181,7 +181,7 @@
     /**
      * (REQUIRED) Whether to generate the .d.ts rollup file.
      */
-    "enabled": true,
+    "enabled": false
 
     /**
      * Specifies the output path for a .d.ts rollup file to be generated without any trimming.
@@ -221,7 +221,7 @@
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
      * DEFAULT VALUE: ""
      */
-    "publicTrimmedFilePath": "dist/package/index.d.ts"
+    // "publicTrimmedFilePath": "dist/package/index.d.ts"
 
     /**
      * When a declaration is trimmed, by default it will be replaced by a code comment such as

--- a/tsconfig.d.json
+++ b/tsconfig.d.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/dts",
+    "outDir": "dist/package",
     "declaration": true,
     "emitDeclarationOnly": true
   },


### PR DESCRIPTION
The file produced by the api-extractor is buggy because it does not contain the following needed declaration:

```ts
declare global {
    interface SymbolConstructor {
        readonly observable: symbol;
    }
}
```

Without this, the `InteropObservable` interface no longer means anything, and type inference fails on all `derived` calls.

The api-extractor does not seem to support globally-scoped augmented declarations, cf [here](https://github.com/microsoft/rushstack/issues/1709#issuecomment-619283014).

This PR simply uses the `index.d.ts` file generated by `tsc` instead of using the result from the api-generator. In this file, the global `Symbol.observable` declaration is not missing and types work fine again.